### PR TITLE
Fix no display if player token not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,15 @@
 -->
 
 ## Unreleased
+
 ### Changed
 
 - Allow any clickable element to focus.
 - Rework all colors. The client is now more accessible: it is compiliant with WCAG on almost all elements with a rating of AA. A better color logic is now used: any element with a clear background can be interacted with.
+
+### Fixed
+
+- Fixed empty player token dialog if no player token exists.
 
 ## 1.9.2 - 2025-03-22
 

--- a/src/components/settings/Tokens.jsx
+++ b/src/components/settings/Tokens.jsx
@@ -72,15 +72,17 @@ class PlayerTokenBox extends Component {
       responseOfRevokePlayerToken,
     } = this.props
     const { data: karaoke } = this.props.karaokeState
-    const { data: playerToken } = this.props.playerTokenState
-    const { status: playerTokenStatus } = this.props.playerTokenState
-    const created = !!playerToken.key
+    const { data: playerToken, status: playerTokenStatus } =
+      this.props.playerTokenState
+    const keyExists = !!playerToken.key
 
-    // display something only if the player token has been fetched
+    // NOTE If the token is not found, the state is still `successful` as this
+    // is a valid case. Check the reducer to see how this case is handled.
+
     let playerTokenBox
     if (playerTokenStatus === Status.successful) {
       let playerTokenBoxContent
-      if (created) {
+      if (keyExists) {
         // display token
         playerTokenBoxContent = (
           <>
@@ -143,7 +145,7 @@ class PlayerTokenBox extends Component {
 
       playerTokenBox = (
         <CSSTransition
-          in={created}
+          in={keyExists}
           classNames="token-player"
           timeout={{
             enter: 300,
@@ -152,6 +154,12 @@ class PlayerTokenBox extends Component {
         >
           {playerTokenBoxContent}
         </CSSTransition>
+      )
+    } else if (playerTokenStatus === Status.failed) {
+      playerTokenBox = (
+        <div className="ribbon danger">
+          <p>Unable to get player token.</p>
+        </div>
       )
     }
 

--- a/src/reducers/playlist.js
+++ b/src/reducers/playlist.js
@@ -327,7 +327,7 @@ function playerToken(state = defaultPlayerToken, action) {
     case PLAYER_TOKEN_FAILURE:
       // if the player token doesn't exist
       // TODO change to low level check
-      if (action.error.detail === 'Not found.') {
+      if (action.error.detail === 'No PlayerToken matches the given query.') {
         return {
           status: Status.successful,
           data: {


### PR DESCRIPTION
This PR fixes a bug where the form to create a player token would not be rendered if no player token exist.

This seemingly appeared when updating the server with DakaraProject/dakara-server#172, where the player token authentication class was changed from completely custom to inherited from a base token authentication. This changed the error message if not found, but no tests existed to check this.

Tests on the server were improved with DakaraProject/dakara-server#177.

Fixes #172.