### PR TITLE
Use hashes for arrays in digest data

### DIFF
--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -30,8 +30,7 @@ class Played extends Component {
     }
 
     // refresh if the playlist changed
-    const { playlistPlayedState } = this.props
-    const { playlistEntriesDigestState } = this.props
+    const { playlistPlayedState, playlistEntriesDigestState } = this.props
     const { playlistEntriesDigestState: prevPlaylistEntriesDigestState } =
       prevProps
     if (

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -6,10 +6,10 @@ import { loadPlaylistEntries } from 'actions/playlist'
 import ListingList from 'components/generics/listing/List'
 import Navigator from 'components/generics/Navigator'
 import PlayedEntry from 'components/playlist/played/Entry'
+import { Status } from 'reducers/alterationsResponse'
 import { playedStatePropType } from 'reducers/playlist'
 import { playlistEntriesDigestStatePropType } from 'reducers/playlistDigest'
 import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
-import { getEntriesHash } from 'utils'
 
 class Played extends Component {
   static propTypes = {
@@ -30,15 +30,17 @@ class Played extends Component {
     }
 
     // refresh if the playlist changed
+    const { playlistPlayedState } = this.props
+    const { playlistEntriesDigestState } = this.props
+    const { playlistEntriesDigestState: prevPlaylistEntriesDigestState } =
+      prevProps
     if (
-      this.props.playlistEntriesDigestState !==
-      prevProps.playlistEntriesDigestState
+      playlistEntriesDigestState !== prevPlaylistEntriesDigestState &&
+      playlistPlayedState.status !== Status.pending &&
+      playlistEntriesDigestState.data.playedEntriesHash !==
+        prevPlaylistEntriesDigestState.data.playedEntriesHash
     ) {
-      const played = this.props.playlistEntriesDigestState.data.playedEntries
-      const prevPlayed = prevProps.playlistEntriesDigestState.data.playedEntries
-      if (played.length !== prevPlayed.length) {
-        this.refreshEntries()
-      }
+      this.refreshEntries()
     }
   }
 
@@ -54,7 +56,7 @@ class Played extends Component {
   render() {
     const { played, count, pagination } = this.props.playlistPlayedState.data
     const { status } = this.props.playlistPlayedState
-    const { playedEntries } = this.props.playlistEntriesDigestState.data
+    const { playedEntriesHash } = this.props.playlistEntriesDigestState.data
 
     const playedComponent = played.map((entry) => (
       <PlayedEntry key={entry.id} entry={entry} />
@@ -64,7 +66,7 @@ class Played extends Component {
       <div id="played">
         <ListingList
           fetchStatus={status}
-          transitionObservable={getEntriesHash(playedEntries)}
+          transitionObservable={playedEntriesHash}
         >
           {playedComponent}
         </ListingList>

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -10,7 +10,6 @@ import { Status } from 'reducers/alterationsResponse'
 import { playerErrorsStatePropType } from 'reducers/playlist'
 import { playerErrorsDigestStatePropType } from 'reducers/playlistDigest'
 import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
-import { getEntriesHash } from 'utils'
 
 class PlayerErrorsList extends Component {
   static propTypes = {
@@ -36,17 +35,11 @@ class PlayerErrorsList extends Component {
     const { playerErrorsDigestState: prevPlayerErrorsDigestState } = prevProps
     if (
       playerErrorsDigestState !== prevPlayerErrorsDigestState &&
-      playerErrorsState.status !== Status.pending
+      playerErrorsState.status !== Status.pending &&
+      playerErrorsDigestState.data.playerErrorsHash !==
+        prevPlayerErrorsDigestState.data.playerErrorsHash
     ) {
-      const errorIds = playerErrorsDigestState.data.playerErrors.map(
-        (e) => e.id
-      )
-      const prevErrorIds = prevPlayerErrorsDigestState.data.playerErrors.map(
-        (e) => e.id
-      )
-      if (errorIds.length !== prevErrorIds.length) {
-        this.refreshEntries()
-      }
+      this.refreshEntries()
     }
   }
 
@@ -57,24 +50,18 @@ class PlayerErrorsList extends Component {
   }
 
   render() {
-    const {
-      playerErrors: errors,
-      count,
-      pagination,
-    } = this.props.playerErrorsState.data
+    const { playerErrors, count, pagination } =
+      this.props.playerErrorsState.data
     const { status } = this.props.playerErrorsState
-    const { playerErrors } = this.props.playerErrorsDigestState.data
+    const { playerErrorsHash } = this.props.playerErrorsDigestState.data
 
-    const errorsList = errors.map((playerError) => (
+    const errorsList = playerErrors.map((playerError) => (
       <PlayerErrorsEntry key={playerError.id} playerError={playerError} />
     ))
 
     return (
       <div id="player-errors-list">
-        <ListingList
-          status={status}
-          transitionObservable={getEntriesHash(playerErrors)}
-        >
+        <ListingList status={status} transitionObservable={playerErrorsHash}>
           {errorsList}
         </ListingList>
         <Navigator

--- a/src/components/playlist/queueing/List.jsx
+++ b/src/components/playlist/queueing/List.jsx
@@ -11,7 +11,6 @@ import { Status } from 'reducers/alterationsResponse'
 import { queuingStatePropType } from 'reducers/playlist'
 import { playlistEntriesDigestStatePropType } from 'reducers/playlistDigest'
 import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
-import { getEntriesHash } from 'utils'
 
 class Queueing extends Component {
   static propTypes = {
@@ -28,32 +27,24 @@ class Queueing extends Component {
     this.refreshEntries()
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     // refresh if moved to a different page
     if (this.props.searchParams !== prevProps.searchParams) {
       this.refreshEntries()
     }
 
     // refresh if the playlist changed
+    const { playlistQueuingState } = this.props
+    const { playlistEntriesDigestState } = this.props
+    const { playlistEntriesDigestState: prevPlaylistEntriesDigestState } =
+      prevProps
     if (
-      this.props.playlistEntriesDigestState !==
-        prevProps.playlistEntriesDigestState &&
-      this.props.playlistQueuingState.status !== Status.pending
+      playlistEntriesDigestState !== prevPlaylistEntriesDigestState &&
+      playlistQueuingState.status !== Status.pending &&
+      playlistEntriesDigestState.data.queuingEntriesHash !==
+        prevPlaylistEntriesDigestState.data.queuingEntriesHash
     ) {
-      const queuingId =
-        this.props.playlistEntriesDigestState.data.queuingEntries.map(
-          (e) => e.id
-        )
-      const prevQueuingId =
-        prevProps.playlistEntriesDigestState.data.queuingEntries.map(
-          (e) => e.id
-        )
-      if (
-        queuingId.length !== prevQueuingId.length ||
-        !queuingId.every((e, i) => e === prevQueuingId[i])
-      ) {
-        this.refreshEntries()
-      }
+      this.refreshEntries()
     }
 
     // if the page of entries could not be obtained, request the previous
@@ -81,7 +72,8 @@ class Queueing extends Component {
   render() {
     const { queuing, count, pagination } = this.props.playlistQueuingState.data
     const { status } = this.props.playlistQueuingState
-    const { queuingEntries } = this.props.playlistEntriesDigestState.data
+    const { queuingEntries, queuingEntriesHash } =
+      this.props.playlistEntriesDigestState.data
 
     const firstId = queuingEntries?.[0]?.id
     const lastId = queuingEntries.slice(-1)?.[0]?.id
@@ -108,7 +100,7 @@ class Queueing extends Component {
       <div id="queuing">
         <ListingList
           fetchStatus={status}
-          transitionObservable={getEntriesHash(queuingEntries)}
+          transitionObservable={queuingEntriesHash}
         >
           {queuingComponents}
         </ListingList>

--- a/src/reducers/playlistDigest.js
+++ b/src/reducers/playlistDigest.js
@@ -12,7 +12,7 @@ import {
   playerErrorPropType,
   playlistEntryPropType,
 } from 'serverPropTypes/playlist'
-import { differentiateEntries } from 'utils'
+import { differentiateEntries, getEntriesHash } from 'utils'
 
 /**
  * This reducer contains playlist digest data related state
@@ -26,8 +26,11 @@ import { differentiateEntries } from 'utils'
 export const playlistEntriesDigestStateDataPropType = PropTypes.shape({
   dateEnd: PropTypes.string.isRequired,
   playedEntries: PropTypes.arrayOf(playlistEntryPropType).isRequired,
+  playedEntriesHash: PropTypes.number.isRequired,
   playingEntries: PropTypes.arrayOf(playlistEntryPropType).isRequired,
+  playingEntriesHash: PropTypes.number.isRequired,
   queuingEntries: PropTypes.arrayOf(playlistEntryPropType).isRequired,
+  queuingEntriesHash: PropTypes.number.isRequired,
 })
 
 export const playlistEntriesDigestStatePropType = PropTypes.shape({
@@ -40,8 +43,11 @@ const defaultEntries = {
   data: {
     dateEnd: '',
     playedEntries: [],
+    playedEntriesHash: 0,
     playingEntries: [],
+    playingEntriesHash: 0,
     queuingEntries: [],
+    queuingEntriesHash: 0,
   },
 }
 
@@ -86,8 +92,11 @@ function entries(state = defaultEntries, action) {
         data: {
           dateEnd: date.toISOString(),
           playedEntries,
+          playedEntriesHash: getEntriesHash(playedEntries),
           playingEntries,
+          playingEntriesHash: getEntriesHash(playingEntries),
           queuingEntries,
+          queuingEntriesHash: getEntriesHash(queuingEntries),
         },
       }
     }
@@ -125,6 +134,7 @@ export const playerErrorsDigestStatePropType = PropTypes.shape({
   status: PropTypes.symbol,
   data: PropTypes.shape({
     playerErrors: PropTypes.arrayOf(playerErrorPropType).isRequired,
+    playerErrorsHash: PropTypes.number.isRequired,
   }),
 })
 
@@ -132,6 +142,7 @@ const defaultPlayerErrors = {
   status: null,
   data: {
     playerErrors: [],
+    playerErrorsHash: 0,
   },
 }
 
@@ -143,13 +154,16 @@ function playerErrors(state = defaultPlayerErrors, action) {
         status: state.status || Status.pending,
       }
 
-    case PLAYLIST_DIGEST_SUCCESS:
+    case PLAYLIST_DIGEST_SUCCESS: {
+      const playerErrors = action.response.player_errors
       return {
         status: Status.successful,
         data: {
-          playerErrors: action.response.player_errors,
+          playerErrors,
+          playerErrorsHash: getEntriesHash(playerErrors),
         },
       }
+    }
 
     case PLAYLIST_DIGEST_FAILURE:
       return {


### PR DESCRIPTION
This PR aims to use hashes for arrays of digest data, which is stored in the state, instead of being recalculated when needed. The hashes are already used in the project, so this PR is more a rationalization of their use.

This should help to convert class components to functional components in the future.