### PR TITLE
Improve listings refresh

### DIFF
--- a/src/components/generics/HighlighterQuery.jsx
+++ b/src/components/generics/HighlighterQuery.jsx
@@ -13,7 +13,7 @@ import Highlighter from 'react-highlight-words'
  *        rendered.
  *    className <string>: CSS class applied to the `Highlighter` and the `span`.
  *    searchWords <array/function>: if provided as an array, it has the same
- *        behavior as in `Highlighter`. If provided as a fanction, it takes the
+ *        behavior as in `Highlighter`. If provided as a function, it takes the
  *        query as argument and must return an array, which is passed to
  *        `Highlighter`.
  *

--- a/src/components/generics/listing/List.jsx
+++ b/src/components/generics/listing/List.jsx
@@ -20,10 +20,11 @@ export default function ListingList({
   const [transitionObservableInitial, _] = useState(transitionObservable)
   const [searchParams, __] = useSearchParams()
 
-  // disable transition if search params changed
+  // disable transition if the page changed
+  const page = searchParams.get('page')
   useEffect(() => {
     setTransition(false)
-  }, [searchParams])
+  }, [page])
 
   // enable transition if a given observable changed, and is different from its
   // initial value when mounted

--- a/src/components/library/SearchBox.jsx
+++ b/src/components/library/SearchBox.jsx
@@ -1,19 +1,14 @@
 import PropTypes from 'prop-types'
-import queryString from 'query-string'
 import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { storeSearchBox } from 'actions/library'
-import {
-  withLocation,
-  withSearchParams,
-} from 'thirdpartyExtensions/ReactRouterDom'
+import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
 import { CSSTransitionLazy } from 'thirdpartyExtensions/ReactTransitionGroup'
 
 class SearchBox extends Component {
   static propTypes = {
     help: PropTypes.element,
-    location: PropTypes.object.isRequired,
     placeholder: PropTypes.string.isRequired,
     searchParams: PropTypes.object.isRequired,
     setSearchParams: PropTypes.func.isRequired,
@@ -28,20 +23,24 @@ class SearchBox extends Component {
 
   componentDidMount() {
     this.updateQueryFromStore()
-    this.updateQueryFromLocation()
+    this.updateQueryFromSearchParams()
   }
 
   componentDidUpdate(prevProps) {
-    const newQueryStore = this.props.searchBox.query
-    if (newQueryStore !== prevProps.searchBox.query) {
+    // update query if the stored query changed
+    const { query } = this.props.searchBox
+    const { query: prevQuery } = prevProps.searchBox
+    if (query !== prevQuery) {
       this.updateQueryFromStore()
     }
 
-    const newQueryLocation = queryString.parse(this.props.location.search).query
-    if (
-      newQueryLocation !== queryString.parse(prevProps.location.search).query
-    ) {
-      this.updateQueryFromLocation()
+    // update query if the URL query changed
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+    const queryUrl = searchParams.get('query')
+    const prevQueryUrl = prevSearchParams.get('query')
+    if (queryUrl !== prevQueryUrl) {
+      this.updateQueryFromSearchParams()
     }
   }
 
@@ -49,8 +48,9 @@ class SearchBox extends Component {
     this.props.storeSearchBox(this.state)
   }
 
-  updateQueryFromLocation = () => {
-    const query = queryString.parse(this.props.location.search).query
+  updateQueryFromSearchParams = () => {
+    const { searchParams } = this.props
+    const query = searchParams.get('query')
     if (query && query.length > 0) {
       this.setState({ query })
     }
@@ -178,7 +178,7 @@ const mapStateToProps = (state) => ({
 })
 
 SearchBox = withSearchParams(
-  withLocation(connect(mapStateToProps, { storeSearchBox })(SearchBox))
+  connect(mapStateToProps, { storeSearchBox })(SearchBox)
 )
 
 export default SearchBox

--- a/src/components/library/artist/List.jsx
+++ b/src/components/library/artist/List.jsx
@@ -32,7 +32,20 @@ class ArtistList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.searchParams !== prevProps.searchParams) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
+    // refresh if moved to a different page
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
       this.refreshEntries()
     }
   }

--- a/src/components/library/artist/List.jsx
+++ b/src/components/library/artist/List.jsx
@@ -64,19 +64,17 @@ class ArtistList extends Component {
     return (
       <div id="artist-library">
         <SearchBox placeholder="Who are you looking for?" />
-        <div className="artist-list">
-          <ListingList fetchStatus={this.props.artistState.status} noTransition>
-            {libraryEntryArtistList}
-          </ListingList>
-          <Navigator
-            count={count}
-            pagination={pagination}
-            names={{
-              singular: 'artist found',
-              plural: 'artists found',
-            }}
-          />
-        </div>
+        <ListingList fetchStatus={this.props.artistState.status} noTransition>
+          {libraryEntryArtistList}
+        </ListingList>
+        <Navigator
+          count={count}
+          pagination={pagination}
+          names={{
+            singular: 'artist found',
+            plural: 'artists found',
+          }}
+        />
       </div>
     )
   }

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -37,7 +37,20 @@ class SongList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.searchParams !== prevProps.searchParams) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
+    // refresh if moved to a different page
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
       this.refreshEntries()
     }
   }

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -113,19 +113,17 @@ class SongList extends Component {
             </>
           }
         />
-        <div className="song-list">
-          <ListingList fetchStatus={this.props.songState.status} noTransition>
-            {libraryEntrySongList}
-          </ListingList>
-          <Navigator
-            count={count}
-            pagination={pagination}
-            names={{
-              singular: 'song found',
-              plural: 'songs found',
-            }}
-          />
-        </div>
+        <ListingList fetchStatus={this.props.songState.status} noTransition>
+          {libraryEntrySongList}
+        </ListingList>
+        <Navigator
+          count={count}
+          pagination={pagination}
+          names={{
+            singular: 'song found',
+            plural: 'songs found',
+          }}
+        />
       </div>
     )
   }

--- a/src/components/library/widgets/Artist.jsx
+++ b/src/components/library/widgets/Artist.jsx
@@ -52,7 +52,16 @@ export default class ArtistWidget extends Component {
         <HighlighterQuery
           className="name"
           query={query}
-          searchWords={(q) => q.artist.contains.concat(q.remaining)}
+          searchWords={(q) => {
+            let words = q.remaining
+
+            // add artist query values if available
+            if (q.artist) {
+              words = words.concat(q.artist.contains)
+            }
+
+            return words
+          }}
           textToHighlight={artist.name}
         />
         {count}

--- a/src/components/library/widgets/Work.jsx
+++ b/src/components/library/widgets/Work.jsx
@@ -56,14 +56,23 @@ export default function WorkWidget({
         query={query}
         className="title"
         searchWords={(q) => {
-          let searchWords = q.work.contains.concat(q.remaining)
-          const workTypeQuery = q.work_type[work.work_type.query_name]
-          if (workTypeQuery) {
-            // Add keyword for specific worktype if it exists
-            searchWords = searchWords.concat(workTypeQuery.contains)
+          let words = q.remaining
+
+          // add work query values if available
+          if (q.work) {
+            words = words.concat(q.work.contains)
           }
 
-          return searchWords
+          // add work_type query values if available
+          if (q.work_type) {
+            const workTypeQuery = q.work_type[work.work_type.query_name]
+            if (workTypeQuery) {
+              // add keyword for specific worktype if it exists
+              words = words.concat(workTypeQuery.contains)
+            }
+          }
+
+          return words
         }}
         textToHighlight={work.title}
       />

--- a/src/components/library/work/List.jsx
+++ b/src/components/library/work/List.jsx
@@ -112,19 +112,17 @@ class WorkList extends Component {
         <SearchBox
           placeholder={`What ${workType.name.toLowerCase()} do you want?`}
         />
-        <div className="work-list">
-          <ListingList fetchStatus={this.props.workState.status} noTransition>
-            {libraryEntryWorkList}
-          </ListingList>
-          <Navigator
-            count={count}
-            pagination={pagination}
-            names={{
-              singular: `${workType.name.toLowerCase()} found`,
-              plural: `${workType.name_plural.toLowerCase()} found`,
-            }}
-          />
-        </div>
+        <ListingList fetchStatus={this.props.workState.status} noTransition>
+          {libraryEntryWorkList}
+        </ListingList>
+        <Navigator
+          count={count}
+          pagination={pagination}
+          names={{
+            singular: `${workType.name.toLowerCase()} found`,
+            plural: `${workType.name_plural.toLowerCase()} found`,
+          }}
+        />
       </div>
     )
   }

--- a/src/components/library/work/List.jsx
+++ b/src/components/library/work/List.jsx
@@ -49,9 +49,26 @@ class WorkList extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
+    // refresh if moved to a different page
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
+      this.refreshEntries()
+    }
+
+    // refresh if work type is different
     if (
       this.props.workTypeState !== prevProps.workTypeState ||
-      this.props.searchParams !== prevProps.searchParams ||
       this.props.params !== prevProps.params
     ) {
       this.refreshEntries()

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -24,8 +24,20 @@ class Played extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
     // refresh if moved to a different page
-    if (this.props.searchParams !== prevProps.searchParams) {
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
       this.refreshEntries()
     }
 
@@ -48,7 +60,7 @@ class Played extends Component {
    */
   refreshEntries = () => {
     this.props.loadPlaylistEntries('played', {
-      page: this.props.searchParams.get('page'),
+      page: this.props.searchParams.get('page') || 1,
     })
   }
 

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -71,7 +71,7 @@ class PlayerErrorsList extends Component {
     ))
 
     return (
-      <div id="player-errors-list">
+      <div id="player-errors">
         <ListingList status={status} transitionObservable={playerErrorsHash}>
           {errorsList}
         </ListingList>

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -24,14 +24,25 @@ class PlayerErrorsList extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
     // refresh if moved to a different page
-    if (this.props.searchParams !== prevProps.searchParams) {
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
       this.refreshEntries()
     }
 
     // refresh if the digest player errors changed
-    const { playerErrorsState } = this.props
-    const { playerErrorsDigestState } = this.props
+    const { playerErrorsState, playerErrorsDigestState } = this.props
     const { playerErrorsDigestState: prevPlayerErrorsDigestState } = prevProps
     if (
       playerErrorsDigestState !== prevPlayerErrorsDigestState &&

--- a/src/components/playlist/queueing/List.jsx
+++ b/src/components/playlist/queueing/List.jsx
@@ -28,14 +28,25 @@ class Queueing extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { searchParams, setSearchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
     // refresh if moved to a different page
-    if (this.props.searchParams !== prevProps.searchParams) {
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
+      this.refreshEntries()
+    }
+
+    // refresh if search changed
+    const query = searchParams.get('query')
+    const prevQuery = prevSearchParams.get('query')
+    if (query !== prevQuery) {
       this.refreshEntries()
     }
 
     // refresh if the playlist changed
-    const { playlistQueuingState } = this.props
-    const { playlistEntriesDigestState } = this.props
+    const { playlistQueuingState, playlistEntriesDigestState } = this.props
     const { playlistEntriesDigestState: prevPlaylistEntriesDigestState } =
       prevProps
     if (
@@ -49,14 +60,10 @@ class Queueing extends Component {
 
     // if the page of entries could not be obtained, request the previous
     // page
-    if (
-      this.props.playlistQueuingState.status === Status.failed &&
-      this.props.searchParams.get('page') > 1
-    ) {
-      const page = this.props.searchParams.get('page')
-      this.props.searchParams.delete('page')
-      this.props.searchParams.append('page', page - 1)
-      this.props.setSearchParams(this.props.searchParams)
+    if (playlistQueuingState.status === Status.failed && page > 1) {
+      searchParams.delete('page')
+      searchParams.append('page', page - 1)
+      setSearchParams(searchParams)
     }
   }
 
@@ -65,7 +72,7 @@ class Queueing extends Component {
    */
   refreshEntries = () => {
     this.props.loadPlaylistEntries('queuing', {
-      page: this.props.searchParams.get('page'),
+      page: this.props.searchParams.get('page') || 1,
     })
   }
 

--- a/src/components/settings/songTags/List.jsx
+++ b/src/components/settings/songTags/List.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import queryString from 'query-string'
 import { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -11,7 +10,7 @@ import SettingsSongTagsEntry from 'components/settings/songTags/Entry'
 import { alterationResponsePropType } from 'reducers/alterationsResponse'
 import { songTagsStatePropType } from 'reducers/songTags'
 import { userPropType } from 'serverPropTypes/users'
-import { withLocation } from 'thirdpartyExtensions/ReactRouterDom'
+import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
 
 class SongTagsList extends Component {
   static propTypes = {
@@ -19,10 +18,10 @@ class SongTagsList extends Component {
     clearAlteration: PropTypes.func.isRequired,
     editSongTag: PropTypes.func.isRequired,
     getSongTagList: PropTypes.func.isRequired,
-    location: PropTypes.object.isRequired,
     responseOfMultipleEdit: PropTypes.objectOf(alterationResponsePropType),
     responseOfMultipleEditColor: PropTypes.objectOf(alterationResponsePropType),
     songTagsState: songTagsStatePropType.isRequired,
+    searchParams: PropTypes.object.isRequired,
   }
 
   componentDidMount() {
@@ -30,24 +29,25 @@ class SongTagsList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const queryObj = queryString.parse(this.props.location.search)
-    const prevqueryObj = queryString.parse(prevProps.location.search)
-    if (queryObj.page !== prevqueryObj.page) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
+    // refresh if moved to a different page
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
       this.refreshEntries()
     }
   }
 
   refreshEntries = () => {
-    const queryObj = queryString.parse(this.props.location.search)
-    const pageNumber = queryObj.page
-    this.props.getSongTagList(pageNumber)
+    this.props.getSongTagList(this.props.searchParams.get('page') || 1)
   }
 
   render() {
     const {
       editSongTag,
       clearAlteration,
-      location,
       authenticatedUser,
       responseOfMultipleEdit,
       responseOfMultipleEditColor,
@@ -83,7 +83,14 @@ class SongTagsList extends Component {
             </table>
           </div>
         </ListingFetchWrapper>
-        <Navigator pagination={pagination} location={location} />
+        <Navigator
+          count={songTags.length}
+          pagination={pagination}
+          names={{
+            singular: 'tag',
+            plural: 'tags',
+          }}
+        />
       </div>
     )
   }
@@ -98,7 +105,7 @@ const mapStateToProps = (state) => ({
   authenticatedUser: state.authenticatedUser,
 })
 
-SongTagsList = withLocation(
+SongTagsList = withSearchParams(
   connect(mapStateToProps, {
     getSongTagList,
     editSongTag,

--- a/src/components/settings/users/List.jsx
+++ b/src/components/settings/users/List.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import queryString from 'query-string'
 import { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -11,7 +10,7 @@ import Navigator from 'components/generics/Navigator'
 import SettingsUserEntry from 'components/settings/users/Entry'
 import { IsUserManager } from 'permissions/Users'
 import { listUsersStatePropType } from 'reducers/users'
-import { withLocation } from 'thirdpartyExtensions/ReactRouterDom'
+import { withSearchParams } from 'thirdpartyExtensions/ReactRouterDom'
 
 class UsersList extends Component {
   static propTypes = {
@@ -19,8 +18,8 @@ class UsersList extends Component {
     deleteUser: PropTypes.func.isRequired,
     getUsers: PropTypes.func.isRequired,
     listUsersState: listUsersStatePropType.isRequired,
-    location: PropTypes.object.isRequired,
     responseOfMultipleDeleteUser: PropTypes.object,
+    searchParams: PropTypes.object.isRequired,
   }
 
   componentDidMount() {
@@ -28,26 +27,24 @@ class UsersList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const queryObj = queryString.parse(this.props.location.search)
-    const prevQueryObj = queryString.parse(prevProps.location.search)
-    if (queryObj.page !== prevQueryObj.page) {
+    const { searchParams } = this.props
+    const { searchParams: prevSearchParams } = prevProps
+
+    // refresh if moved to a different page
+    const page = searchParams.get('page')
+    const prevPage = prevSearchParams.get('page')
+    if (page !== prevPage) {
       this.refreshEntries()
     }
   }
 
   refreshEntries = () => {
-    const queryObj = queryString.parse(this.props.location.search)
-    const pageNumber = queryObj.page
-    this.props.getUsers(pageNumber)
+    this.props.getUsers(this.props.searchParams.get('page') || 1)
   }
 
   render() {
-    const {
-      deleteUser,
-      clearAlteration,
-      location,
-      responseOfMultipleDeleteUser,
-    } = this.props
+    const { deleteUser, clearAlteration, responseOfMultipleDeleteUser } =
+      this.props
     const { users, pagination } = this.props.listUsersState.data
 
     const userList = users.map((user) => (
@@ -84,7 +81,14 @@ class UsersList extends Component {
             </table>
           </div>
         </ListingFetchWrapper>
-        <Navigator pagination={pagination} location={location} />
+        <Navigator
+          count={users.length}
+          pagination={pagination}
+          names={{
+            singular: 'user',
+            plural: 'users',
+          }}
+        />
         <IsUserManager>
           <div className="create-user flow">
             <FormBlock
@@ -138,7 +142,7 @@ const mapStateToProps = (state) => ({
     state.alterationsResponse.multiple.deleteUser || {},
 })
 
-UsersList = withLocation(
+UsersList = withSearchParams(
   connect(mapStateToProps, {
     deleteUser,
     getUsers,


### PR DESCRIPTION
- Reduce refreshing of components based on listings only if something valuable changed (i.e., the page or the search query);
- Fix bug when searching artists or works: the widgets are now more robust for the content of the query for highlights;
- Simplified some components based on listing (removing of an extra `<div>`);
- Drop the use of `location` for `searchParams` whenever possible;
- Display number of song tags and users in the settings pages;