### PR TITLE
Add buttons to manually move the carousel

### DIFF
--- a/src/components/generics/Carousel.jsx
+++ b/src/components/generics/Carousel.jsx
@@ -15,6 +15,7 @@ export function Carousel({ children, className }) {
         stopOnMouseEnter: true,
         stopOnFocusIn: true,
         stopOnInteraction: false,
+        rootNode: (emblaRoot) => emblaRoot.parentElement,
       }),
       WheelGesturesPlugin({
         forceWheelAxis: 'y',

--- a/src/components/generics/Carousel.jsx
+++ b/src/components/generics/Carousel.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types'
 import { isDisplayable } from 'utils'
 
 export function Carousel({ children, className }) {
-  const [emblaRef] = useEmblaCarousel(
+  const [emblaRef, emblaApi] = useEmblaCarousel(
     { loop: true, duration: 20, skipSnaps: true },
     [
       Autoplay({
@@ -23,8 +23,28 @@ export function Carousel({ children, className }) {
   )
 
   return (
-    <div className={classNames('carousel', className)} ref={emblaRef}>
-      <ul className="viewport">{children}</ul>
+    <div className={classNames('carousel', className)}>
+      <div className="structure" ref={emblaRef}>
+        <ul className="viewport">{children}</ul>
+      </div>
+      <div className="controls compact">
+        <button
+          className="control square primary"
+          onClick={() => emblaApi.scrollNext()}
+        >
+          <span className="icon">
+            <i className="las la-angle-right"></i>
+          </span>
+        </button>
+        <button
+          className="control square primary"
+          onClick={() => emblaApi.scrollPrev()}
+        >
+          <span className="icon">
+            <i className="las la-angle-left"></i>
+          </span>
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/generics/Carousel.jsx
+++ b/src/components/generics/Carousel.jsx
@@ -29,7 +29,7 @@ export function Carousel({ children, className }) {
       </div>
       <div className="controls compact">
         <button
-          className="control square primary"
+          className="control smashed primary listable"
           onClick={() => emblaApi.scrollNext()}
         >
           <span className="icon">
@@ -37,7 +37,7 @@ export function Carousel({ children, className }) {
           </span>
         </button>
         <button
-          className="control square primary"
+          className="control smashed primary listable"
           onClick={() => emblaApi.scrollPrev()}
         >
           <span className="icon">

--- a/src/components/generics/listing/Entry.jsx
+++ b/src/components/generics/listing/Entry.jsx
@@ -126,7 +126,7 @@ function Expander({ children, setExpanded }) {
       }}
     >
       <div className="controls">
-        <div className="control neutral square expand-button">
+        <div className="control neutral smashed">
           <span className="icon">
             <i className="las la-ellipsis-v"></i>
           </span>

--- a/src/components/karaoke/player/Player.jsx
+++ b/src/components/karaoke/player/Player.jsx
@@ -76,7 +76,7 @@ export default function Player() {
       )}
       <Collapse in={hasControls}>
         <div className="transition">
-          <div className="controls">
+          <div className="controls player">
             <ManageButton
               responseOfManage={responseOfSendPlayerCommandsSafe.restart}
               onClick={() => {

--- a/src/style/abstracts/_controls.scss
+++ b/src/style/abstracts/_controls.scss
@@ -23,8 +23,18 @@
     font-size: $text-size;
     height: $height;
 
+    // square buttons are good for icons
     &.square {
       min-width: $height;
+    }
+
+    // smashed buttons are good when used on the borders of the page
+    &.smashed {
+      min-width: 0.5 * $height;
+
+      .icon {
+        font-size: calc($icon-size / $text-size * 0.85em);
+      }
     }
 
     .icon {

--- a/src/style/components/generics/_carousel.scss
+++ b/src/style/components/generics/_carousel.scss
@@ -8,12 +8,22 @@
 @use '~/abstracts/support';
 
 .carousel {
+  display: flex;
   overflow: hidden;
 
-  .viewport {
-    display: flex;
-    list-style-type: none;
-    padding: 0;
+  .structure {
+    flex-grow: 1;
+    overflow: hidden;
+
+    .viewport {
+      display: flex;
+      list-style-type: none;
+      padding: 0;
+    }
+  }
+
+  .controls {
+    flex-direction: column;
   }
 
   .carousel-entry {

--- a/src/style/components/generics/listing/_listing.scss
+++ b/src/style/components/generics/listing/_listing.scss
@@ -104,14 +104,6 @@ $listing-entry-control-icon-size: sizes.$row-icon-font-size;
         &:focus {
           background: colors.$neutral-112;
         }
-
-        @include support.make-smartphone {
-          .expand-button {
-            // stretch button horizontally to save space
-            min-width: 0.33 * $listing-entry-height;
-            width: 0.33 * $listing-entry-height;
-          }
-        }
       }
 
       .sub-line {

--- a/src/style/components/karaoke/player/_player.scss
+++ b/src/style/components/karaoke/player/_player.scss
@@ -49,7 +49,7 @@ $player-progressbar-height: 0.4rem;
   }
 
   // `controls` class: buttons to send commands to the player.
-  .controls {
+  .controls.player {
     @include sizes.make-gap(margin, bottom);
     @include controls.make-controls($player-controls-height);
     @include support.make-smartphone {

--- a/src/style/layout/_controls.scss
+++ b/src/style/layout/_controls.scss
@@ -46,8 +46,8 @@
     padding: 0;
     text-decoration: none;
 
-    // non-square buttons have padding
-    &:not(.square) {
+    // non-square and non-smashed buttons have padding
+    &:not(.square):not(.smashed) {
       @include sizes.make-gap(padding, horizontal);
     }
 


### PR DESCRIPTION
Add buttons for the carousel. The carousel stops moving when the user interacts with the buttons.

Side effect: the smashed controls can be used on the horizontal border of the page for smaller buttons.