### PR TITLE
Fix lint errors

### DIFF
--- a/src/components/generics/NotificationBar.jsx
+++ b/src/components/generics/NotificationBar.jsx
@@ -23,9 +23,13 @@ export default function NotificationBar({
   successfulMessage = 'Success',
   noDisplayOnMount = false,
 }) {
-  const [lastState, setLastState] = useState({ status: null, date: null })
-  const [show, setShow] = useState(false)
-  const [hideTimeout, setHideTimeout] = useState(null)
+  const [lastState, setLastState] = useState({
+    status: null,
+    date: null,
+    show: false,
+  })
+  let { show } = lastState
+  let hideTimeout = null
 
   const durations = {
     [Status.successful]: successfulDuration,
@@ -38,22 +42,20 @@ export default function NotificationBar({
     date &&
     (status !== lastState.status || date !== lastState.date)
   ) {
-    setLastState({ status, date })
-    setShow(true)
+    show = true
+    setLastState({ status, date, show })
 
     // schedule to hide the notification only when a non-pending status has
     // been reached
     const duration = durations[status]
     if (status !== Status.pending && duration) {
-      setHideTimeout(
-        setTimeout(() => {
-          setShow(false)
-        }, duration)
-      )
+      hideTimeout = setTimeout(() => {
+        setLastState((state) => ({ ...state, show: false }))
+      }, duration)
     }
   }
 
-  // clear the schedule to hide the notification if it changes
+  // clear the previous schedule to hide the notification if it changes
   useEffect(
     () => () => {
       if (hideTimeout) {

--- a/src/components/generics/NotificationBar.jsx
+++ b/src/components/generics/NotificationBar.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import Slide from 'components/transitions/Slide'
 import {
@@ -27,21 +27,10 @@ export default function NotificationBar({
   const [show, setShow] = useState(false)
   const [hideTimeout, setHideTimeout] = useState(null)
 
-  const durations = useMemo(
-    () => ({
-      [Status.successful]: successfulDuration,
-      [Status.failed]: failedDuration,
-    }),
-    [successfulDuration, failedDuration]
-  )
-  const messages = useMemo(
-    () => ({
-      [Status.pending]: pendingMessage,
-      [Status.successful]: successfulMessage,
-      [Status.failed]: failedMessage,
-    }),
-    [pendingMessage, successfulMessage, failedMessage]
-  )
+  const durations = {
+    [Status.successful]: successfulDuration,
+    [Status.failed]: failedDuration,
+  }
 
   const { status, date } = alterationResponse
   if (
@@ -95,10 +84,16 @@ export default function NotificationBar({
         return message
       }
 
+      const messages = {
+        [Status.pending]: pendingMessage,
+        [Status.successful]: successfulMessage,
+        [Status.failed]: failedMessage,
+      }
+
       // default to specified messages
       return messages[status]
     },
-    [messages]
+    [pendingMessage, successfulMessage, failedMessage]
   )
 
   const notificationMessage = getMessage(alterationResponse)

--- a/src/components/generics/NotificationBar.jsx
+++ b/src/components/generics/NotificationBar.jsx
@@ -23,7 +23,9 @@ export default function NotificationBar({
   successfulMessage = 'Success',
   noDisplayOnMount = false,
 }) {
+  const [lastState, setLastState] = useState({ status: null, date: null })
   const [show, setShow] = useState(false)
+  const [hideTimeout, setHideTimeout] = useState(null)
 
   const durations = useMemo(
     () => ({
@@ -42,10 +44,46 @@ export default function NotificationBar({
   )
 
   const { status, date } = alterationResponse
+  if (
+    status &&
+    date &&
+    (status !== lastState.status || date !== lastState.date)
+  ) {
+    setLastState({ status, date })
+    setShow(true)
 
+    // schedule to hide the notification only when a non-pending status has
+    // been reached
+    const duration = durations[status]
+    if (status !== Status.pending && duration) {
+      setHideTimeout(
+        setTimeout(() => {
+          setShow(false)
+        }, duration)
+      )
+    }
+  }
+
+  // clear the schedule to hide the notification if it changes
+  useEffect(
+    () => () => {
+      if (hideTimeout) {
+        clearTimeout(hideTimeout)
+      }
+    },
+    [hideTimeout]
+  )
+
+  // get the correct message to display in the notification, depending on the
+  // alteration response and the component's values
   const getMessage = useCallback(
     (alterationResponse) => {
       const { status, fields, message } = alterationResponse
+
+      // leave early if blank alteration response
+      if (!status) {
+        return
+      }
 
       // specific case if the alteration response contains field errors
       if (fields && Object.keys(fields).length) {
@@ -63,45 +101,19 @@ export default function NotificationBar({
     [messages]
   )
 
-  useEffect(() => {
-    if (!status || !date) {
-      return
-    }
-
-    // display if status and date changed and have a valid value
-    // TODO fix state modification within useEffect
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setShow(true)
-
-    // request to hide success or failure message only after a certain time
-    let timeout
-    if (status !== Status.pending && durations[status]) {
-      timeout = setTimeout(() => {
-        setShow(false)
-      }, durations[status])
-    }
-
-    return () => {
-      if (timeout) {
-        clearTimeout(timeout)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, date])
-
   const notificationMessage = getMessage(alterationResponse)
-
-  if (!notificationMessage) {
-    return null
-  }
 
   return (
     <Slide in={show}>
-      <div className="notification-bar notified transition">
-        <div className={`notification non-hoverizable ${types[status] || ''}`}>
-          <div className="message">{notificationMessage}</div>
+      {notificationMessage && (
+        <div className="notification-bar notified transition">
+          <div
+            className={`notification non-hoverizable ${types[status] || ''}`}
+          >
+            <div className="message">{notificationMessage}</div>
+          </div>
         </div>
-      </div>
+      )}
     </Slide>
   )
 }

--- a/src/components/generics/SearchBox.jsx
+++ b/src/components/generics/SearchBox.jsx
@@ -55,13 +55,12 @@ SearchBoxHelp.propTypes = {
 export default function SearchBox({ help, placeholder, query, setQuery }) {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const queryFromParams = searchParams.get('query')
-
   const [displayed, setDisplayed] = useState(false)
 
   useEffect(
     () => {
       // update query from URL immediately
+      const queryFromParams = searchParams.get('query')
       if (queryFromParams !== null) {
         setQuery(queryFromParams)
       }

--- a/src/components/generics/TokenWidget.jsx
+++ b/src/components/generics/TokenWidget.jsx
@@ -5,7 +5,10 @@ import NotificationBar from 'components/generics/NotificationBar'
 import { Status } from 'reducers/alterationsResponse'
 
 export default function TokenWidget({ token }) {
-  const [tokenCopyStatus, setTokenCopyStatus] = useState()
+  const [tokenCopyState, setTokenCopyState] = useState({
+    status: null,
+    date: null,
+  })
 
   return (
     <div className="token-widget notifiable">
@@ -16,13 +19,16 @@ export default function TokenWidget({ token }) {
           onClick={() => {
             // copy text to clipboard using the clipboard API and manage
             // success or failure of the operation
-            setTokenCopyStatus(Status.pending)
+            setTokenCopyState({ status: Status.pending, date: Date.now() })
             navigator.clipboard.writeText(token).then(
               () => {
-                setTokenCopyStatus(Status.successful)
+                setTokenCopyState({
+                  status: Status.successful,
+                  date: Date.now(),
+                })
               },
               () => {
-                setTokenCopyStatus(Status.failed)
+                setTokenCopyState({ status: Status.failed, date: Date.now() })
               }
             )
           }}
@@ -33,10 +39,7 @@ export default function TokenWidget({ token }) {
         </button>
       </div>
       <NotificationBar
-        alterationResponse={{
-          status: tokenCopyStatus,
-          date: -1, // XXX There should be a valid date here
-        }}
+        alterationResponse={tokenCopyState}
         successfulMessage="Copied!"
         failedMessage="Error when copying to clipboard"
       />

--- a/src/components/generics/listing/Entry.jsx
+++ b/src/components/generics/listing/Entry.jsx
@@ -28,16 +28,12 @@ export function ListingEntry({
   // component
   const expanded = expandable && parseInt(searchParams.get('expanded')) === id
 
-  useEffect(
-    () => {
-      // manage on toggle callback if any
-      if (typeof onToggle === 'function') {
-        onToggle(expanded)
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [expanded]
-  )
+  useEffect(() => {
+    // manage on toggle callback if any
+    if (typeof onToggle === 'function') {
+      onToggle(expanded)
+    }
+  }, [expanded, onToggle])
 
   const setExpanded = () => {
     // called when clicking the expand button, so it means the expanded

--- a/src/components/generics/listing/List.jsx
+++ b/src/components/generics/listing/List.jsx
@@ -5,40 +5,95 @@ import { useSearchParams } from 'react-router'
 import { TransitionGroup } from 'react-transitioning'
 
 import ListingFetchWrapper from 'components/generics/listing/FetchWrapper'
-import Collapse from 'components/transitions/Collapse'
+import Collapse, { COLLAPSE_DURATION } from 'components/transitions/Collapse'
 import { ListingNoTransitionContext } from 'contexts/listing'
+import { Status } from 'reducers/alterationsResponse'
 
+// If requested, the animation of the items entering and exiting in this
+// component is touchy. Basically, I want to animate them on the same page,
+// when fetched, when a user (current one or another one) interacted with the
+// entries. But from the point of view of the store, it is difficult to track
+// such interaction: the entries change when changing the page, by instance.
+// What I can track is:
+//
+// - The entries (all entries, not only the ones in the page), through the hash,
+// (if the entries changed, there may be a transition);
+// - The page (if the page changed, there is no transition);
+// - If the entries have been fetched at least once (if this is the first time
+// the entries are displayed, there is no transition).
+//
+// So I came up with this component below, which has a quite alambicated logic.
+// I am still wondering if such gearing was necessary...
 export default function ListingList({
   entries,
   fetchStatus,
   free,
   mini,
   noTransition,
-  transitionObservable = null,
+  hash = null,
 }) {
   const className = classNames('listing', { free, mini })
 
-  const [transition, setTransition] = useState(false)
-  const [transitionObservableInitial, _] = useState(transitionObservable)
-  const [searchParams, __] = useSearchParams()
+  const [lastState, setLastState] = useState({
+    page: null,
+    hash: null,
+    firstLoad: true,
+    transition: false,
+  })
+  let { transition } = lastState
+  let transitionTimeout = null
 
-  // disable transition if the page changed
-  const page = searchParams.get('page')
-  useEffect(() => {
-    // TODO fix state modification within useEffect
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setTransition(false)
-  }, [page])
+  const [searchParams, _] = useSearchParams()
 
-  // enable transition if a given observable changed, and is different from its
-  // initial value when mounted
-  useEffect(() => {
-    if (transitionObservable != transitionObservableInitial) {
-      // TODO fix state modification within useEffect
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setTransition(true)
+  if (!noTransition) {
+    const page = searchParams.get('page')
+
+    // detect entries have been fetched once
+    let { firstLoad } = lastState
+    if (firstLoad) {
+      if (fetchStatus !== Status.pending) {
+        firstLoad = false
+      }
     }
-  }, [transitionObservable, transitionObservableInitial])
+
+    // allow transition evaluation if the page is the same, and the entries
+    // have been fetched once
+    if (page === lastState.page && !lastState.firstLoad) {
+      // allow transition if hash changed
+      if (hash !== lastState.hash) {
+        transition = true
+        // schedule to disable transition later
+        transitionTimeout = setTimeout(() => {
+          setLastState((state) => ({ ...state, transition: false }))
+        }, COLLAPSE_DURATION)
+      }
+    } else {
+      transition = false
+      // cancel the schedule to disable transition
+      transitionTimeout = null
+    }
+
+    // update the state selectively
+    const newState = { hash, page, firstLoad, transition }
+    if (
+      hash !== lastState.hash ||
+      page !== lastState.page ||
+      firstLoad !== lastState.firstLoad ||
+      transition !== lastState.transition
+    ) {
+      setLastState(newState)
+    }
+  }
+
+  // clear the previous schedule to disable transition if it changes
+  useEffect(
+    () => () => {
+      if (transitionTimeout) {
+        clearTimeout(transitionTimeout)
+      }
+    },
+    [transitionTimeout]
+  )
 
   const content = (
     <ListingNoTransitionContext.Provider value={noTransition}>
@@ -71,5 +126,5 @@ ListingList.propTypes = {
   free: PropTypes.bool,
   mini: PropTypes.bool,
   noTransition: PropTypes.bool,
-  transitionObservable: PropTypes.any,
+  hash: PropTypes.any,
 }

--- a/src/components/generics/listing/List.jsx
+++ b/src/components/generics/listing/List.jsx
@@ -73,7 +73,7 @@ export default function ListingList({
       transitionTimeout = null
     }
 
-    // update the state selectively
+    // update the state if needed
     const newState = { hash, page, firstLoad, transition }
     if (
       hash !== lastState.hash ||

--- a/src/components/karaoke/Karaoke.jsx
+++ b/src/components/karaoke/Karaoke.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { loadPlaylistDigest } from 'actions/playlistDigest'
@@ -33,7 +33,7 @@ export default function Karaoke() {
   )
 
   const { data: karaoke } = karaokeState
-  const displayIsBlocked = useRef(true)
+  const [displayIsBlocked, setDisplayIsBlocked] = useState(true)
 
   // do not display anything until first load of digest
   if (!karaokeStatus) {
@@ -41,14 +41,14 @@ export default function Karaoke() {
   }
 
   // do not display anything until the digest has been loaded at least once
-  // TODO fix use of refs
-  // eslint-disable-next-line react-hooks/refs
-  if (displayIsBlocked.current && karaokeStatus === Status.pending) {
+  if (displayIsBlocked) {
+    if (karaokeStatus === Status.pending) {
+      return null
+    }
+
+    setDisplayIsBlocked(false)
     return null
   }
-  // TODO fix use of refs
-  // eslint-disable-next-line react-hooks/refs
-  displayIsBlocked.current = false
 
   if (!karaoke.ongoing) {
     if (isPlaylistManager(user)) {

--- a/src/components/library/widgets/SongExpanded.jsx
+++ b/src/components/library/widgets/SongExpanded.jsx
@@ -35,13 +35,11 @@ export default function SongExpanded({ query, song }) {
 
   // Clear song lyrics status on unmount to prevent re-displaying notification
   useEffect(
-    () => {
-      return () => {
-        dispatch(clearSongLyricsStatus(song.id))
-      }
+    () => () => {
+      dispatch(clearSongLyricsStatus(song.id))
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [song.id]
   )
 
   // works

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -58,7 +58,7 @@ export default function PlayedList() {
       <ListingList
         entries={playedComponent}
         fetchStatus={playlistPlayedStatus}
-        transitionObservable={playedEntriesHash}
+        hash={playedEntriesHash}
       />
       <Navigator
         count={count}

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -58,7 +58,7 @@ export default function PlayerErrorsList() {
       <ListingList
         entries={errorsList}
         status={playerErrorsStatus}
-        transitionObservable={playerErrorsHash}
+        hash={playerErrorsHash}
       />
       <Navigator
         count={count}

--- a/src/components/playlist/queuing/Entry.jsx
+++ b/src/components/playlist/queuing/Entry.jsx
@@ -192,6 +192,11 @@ export default function QueuingEntry({ entry, positions, ...rest }) {
   const expanded = reorderId === entry.id
   const inReorder = !(isNaN(reorderId) || isNaN(reorderIndex))
 
+  // hide confirmation bar on collapse
+  if (!expanded && confirmDisplayed) {
+    setConfirmDisplayed(false)
+  }
+
   const controlSearch = (
     <Link
       key="search"

--- a/src/components/playlist/queuing/List.jsx
+++ b/src/components/playlist/queuing/List.jsx
@@ -86,7 +86,7 @@ export default function QueuingList() {
       <ListingList
         entries={queuingComponents}
         fetchStatus={playlistQueuingStatus}
-        transitionObservable={queuingEntriesHash}
+        hash={queuingEntriesHash}
       />
       <Navigator
         count={count}

--- a/src/components/transitions/Collapse.jsx
+++ b/src/components/transitions/Collapse.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types'
 import { CSSTransition } from 'react-transitioning'
 
+export const COLLAPSE_DURATION = 300
+
 export default function Collapse({
   in: inProp,
-  duration = 300,
+  duration = COLLAPSE_DURATION,
   horizontal = false,
   force = false,
   children,


### PR DESCRIPTION
Fixes #252:

- [x] `NotificationBar`: use of a `lastState` to  store the latest known valid state, instead of setting state within `useEffect`;
- [x] `Karaoke`: use state instead of using refs; and
- [x] `ListingList`: use of `lastState` instead of seting state within `useEffect`.

Side effect:

- Clean-up calls to `useEffect`;
- Hide confirmatiion bar on collapse in `QueuingEntry`; and
- Renamed `transitionObservable` to `hash`.