### PR TITLE
Fix listings search parameters not cleaned up on page change

### DIFF
--- a/src/components/generics/Navigator.jsx
+++ b/src/components/generics/Navigator.jsx
@@ -15,6 +15,10 @@ function PaginatorLink({ page, icon, disabled }) {
   const [searchParams, _] = useSearchParams()
   searchParams.set('page', page)
 
+  // delete any known unwanted parameter when changing page
+  searchParams.delete('expanded')
+  searchParams.delete('reorder')
+
   return (
     <Link
       to={{ search: searchParams.toString() }}

--- a/src/components/generics/Navigator.jsx
+++ b/src/components/generics/Navigator.jsx
@@ -11,13 +11,16 @@ const paginationType = PropTypes.shape({
   last: PropTypes.number.isRequired,
 })
 
-function PaginatorLink({ page, icon, disabled }) {
+function PaginatorLink({ page, icon, disabled, cleanupParams }) {
   const [searchParams, _] = useSearchParams()
   searchParams.set('page', page)
 
   // delete any known unwanted parameter when changing page
-  searchParams.delete('expanded')
-  searchParams.delete('reorder')
+  if (cleanupParams) {
+    cleanupParams.forEach((param) => {
+      searchParams.delete(param)
+    })
+  }
 
   return (
     <Link
@@ -37,9 +40,10 @@ PaginatorLink.propTypes = {
   page: PropTypes.number.isRequired,
   icon: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  cleanupParams: PropTypes.arrayOf(PropTypes.string),
 }
 
-function Paginator({ pagination }) {
+function Paginator({ pagination, ...rest }) {
   const { current, last } = pagination
 
   const hasNext = current < last
@@ -51,21 +55,25 @@ function Paginator({ pagination }) {
         page={1}
         icon="las la-angle-double-left"
         disabled={!hasPrevious}
+        {...rest}
       />
       <PaginatorLink
         page={current - 1}
         icon="las la-angle-left"
         disabled={!hasPrevious}
+        {...rest}
       />
       <PaginatorLink
         page={current + 1}
         icon="las la-angle-right"
         disabled={!hasNext}
+        {...rest}
       />
       <PaginatorLink
         page={last}
         icon="las la-angle-double-right"
         disabled={!hasNext}
+        {...rest}
       />
     </nav>
   )
@@ -91,10 +99,10 @@ Counter.propTypes = {
   count: PropTypes.number.isRequired,
 }
 
-export default function Navigator({ count, names, pagination }) {
+export default function Navigator({ count, names, pagination, ...rest }) {
   return (
     <div className="navigator">
-      {pagination && <Paginator pagination={pagination} />}
+      {pagination && <Paginator pagination={pagination} {...rest} />}
       {names && count >= 0 && <Counter names={names} count={count} />}
     </div>
   )

--- a/src/components/generics/Navigator.jsx
+++ b/src/components/generics/Navigator.jsx
@@ -11,13 +11,13 @@ const paginationType = PropTypes.shape({
   last: PropTypes.number.isRequired,
 })
 
-function PaginatorLink({ page, icon, disabled, cleanupParams }) {
+function PaginatorLink({ page, icon, disabled, paramsToCleanup }) {
   const [searchParams, _] = useSearchParams()
   searchParams.set('page', page)
 
   // delete any known unwanted parameter when changing page
-  if (cleanupParams) {
-    cleanupParams.forEach((param) => {
+  if (paramsToCleanup) {
+    paramsToCleanup.forEach((param) => {
       searchParams.delete(param)
     })
   }
@@ -40,7 +40,7 @@ PaginatorLink.propTypes = {
   page: PropTypes.number.isRequired,
   icon: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  cleanupParams: PropTypes.arrayOf(PropTypes.string),
+  paramsToCleanup: PropTypes.arrayOf(PropTypes.string),
 }
 
 function Paginator({ pagination, ...rest }) {

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -79,6 +79,7 @@ export default function SongList() {
           singular: 'song',
           plural: 'songs',
         }}
+        cleanupParams={['expanded']}
       />
     </div>
   )

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -79,7 +79,7 @@ export default function SongList() {
           singular: 'song',
           plural: 'songs',
         }}
-        cleanupParams={['expanded']}
+        paramsToCleanup={['expanded']}
       />
     </div>
   )

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -67,6 +67,7 @@ export default function PlayedList() {
           singular: 'entry',
           plural: 'entries',
         }}
+        cleanupParams={['expanded']}
       />
     </div>
   )

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -67,7 +67,7 @@ export default function PlayedList() {
           singular: 'entry',
           plural: 'entries',
         }}
-        cleanupParams={['expanded']}
+        paramsToCleanup={['expanded']}
       />
     </div>
   )

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -67,6 +67,7 @@ export default function PlayerErrorsList() {
           singular: 'error',
           plural: 'errors',
         }}
+        cleanupParams={['expanded']}
       />
     </div>
   )

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -67,7 +67,7 @@ export default function PlayerErrorsList() {
           singular: 'error',
           plural: 'errors',
         }}
-        cleanupParams={['expanded']}
+        paramsToCleanup={['expanded']}
       />
     </div>
   )

--- a/src/components/playlist/queuing/List.jsx
+++ b/src/components/playlist/queuing/List.jsx
@@ -95,7 +95,7 @@ export default function QueuingList() {
           singular: 'entry',
           plural: 'entries',
         }}
-        cleanupParams={['expanded', 'reorder']}
+        paramsToCleanup={['expanded', 'reorder']}
       />
     </div>
   )

--- a/src/components/playlist/queuing/List.jsx
+++ b/src/components/playlist/queuing/List.jsx
@@ -95,6 +95,7 @@ export default function QueuingList() {
           singular: 'entry',
           plural: 'entries',
         }}
+        cleanupParams={['expanded', 'reorder']}
       />
     </div>
   )


### PR DESCRIPTION
This PR allows to remove any search parameters when changing page with the Navigator component.