### PR TITLE
Include fonts in archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 - Allow to display full lyrics of a song.
 - Add a return button in user edit page.
+- Fonts are now bundled with the release archive.
 
 ### Changed
 

--- a/index.html
+++ b/index.html
@@ -4,13 +4,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Dakara</title>
-  <meta name="description" content="Dakara web client" />
 
-  <!-- Design -->
-  <link rel="stylesheet"
-    href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,200,700,300" type="text/css">
+  <title>Dakara</title>
+  <meta name="apple-mobile-web-app-title" content="Dakara">
+  <meta name="application-name" content="Dakara">
+  <meta name="description" content="Dakara web client" />
 
   <!--Favicons-->
   <link rel="apple-touch-icon" sizes="120x120" href="/favicons/apple-touch-icon.png">
@@ -19,11 +17,9 @@
   <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#8612a1">
   <link rel="shortcut icon" href="/favicons/favicon.ico">
 
-  <meta name="apple-mobile-web-app-title" content="Dakara">
-  <meta name="application-name" content="Dakara">
+  <!--Color-->
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#8612a1">
-
   <link rel="manifest" href="/manifest.json">
   <meta name="msapplication-config" content="/browserconfig.xml">
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.10.0-dev",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/roboto": "^5.3.0",
         "classnames": "^2.5.1",
         "color-convert": "^3.1.3",
         "dayjs": "^1.11.21",
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "embla-carousel-wheel-gestures": "^8.1.0",
+        "line-awesome": "^1.3.0",
         "prop-types": "^15.8.1",
         "query-string": "^9.4.0",
         "react": "^19.2.7",
@@ -650,6 +652,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.3.0.tgz",
+      "integrity": "sha512-BapRJOWYP+LZ21zp+wBQjfpPYKRoxc4LspJ/RLuI+HSMBD5u/X4O+ESDrSvEqDSy0rAl7GwBJ+09mdc16cVQ1Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4462,6 +4473,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/line-awesome": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/line-awesome/-/line-awesome-1.3.0.tgz",
+      "integrity": "sha512-Y0YHksL37ixDsHz+ihCwOtF5jwJgCDxQ3q+zOVgaSW8VugHGTsZZXMacPYZB1/JULBi6BAuTCTek+4ZY/UIwcw==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "lint-css"
   ],
   "dependencies": {
+    "@fontsource/roboto": "^5.3.0",
     "classnames": "^2.5.1",
     "color-convert": "^3.1.3",
     "dayjs": "^1.11.21",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
+    "line-awesome": "^1.3.0",
     "prop-types": "^15.8.1",
     "query-string": "^9.4.0",
     "react": "^19.2.7",

--- a/src/style/thirdparty/_index.scss
+++ b/src/style/thirdparty/_index.scss
@@ -4,5 +4,14 @@
 // Third party style file
 //
 
-@use 'normalize.css/normalize.css';
+@forward 'normalize.css/normalize.css';
+
+@forward '@fontsource/roboto/200.css';
+@forward '@fontsource/roboto/300.css';
+@forward '@fontsource/roboto/400.css';
+@forward '@fontsource/roboto/700.css';
+@forward '@fontsource/roboto/700.css';
+
+@forward 'line-awesome/dist/line-awesome/css/line-awesome.min.css';
+
 @use 'preboot';


### PR DESCRIPTION
Fonts (Roboto and Line Awesome) are now treated as dependencies and included at CSS level (just like `normalize.css`). They will be part of the archive now.

Fixes #268.