### PR TITLE
Fix desynchronized search boxes

### DIFF
--- a/src/components/library/artist/List.jsx
+++ b/src/components/library/artist/List.jsx
@@ -24,7 +24,6 @@ export default function ArtistList() {
       // refresh immediately, or if moved to a different page, or if the search query
       // changed
       dispatch(loadLibraryEntries('artists', page, query))
-      setSearchBoxQuery(query || '')
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [page, query]

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -26,9 +26,9 @@ export default function SongList() {
 
   useEffect(
     () => {
-      // fetch songs from server immediately, and if the page or if the query changes
+      // fetch songs from server immediately, and if the page or if the query
+      // changes
       dispatch(loadLibraryEntries('songs', page, query))
-      setSearchBoxQuery(query || '')
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [page, query]

--- a/src/components/library/work/List.jsx
+++ b/src/components/library/work/List.jsx
@@ -41,9 +41,9 @@ export default function WorkList() {
         return
       }
 
-      // load entries if the page, the query, the work type, or the work thype status changes
+      // load entries if the page, the query, the work type, or the work thype
+      // status changes
       dispatch(loadLibraryEntries('works', page, query, workTypeQueryName))
-      setSearchBoxQuery(query || '')
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [page, query, workTypeQueryName, workTypeStatus]

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -30,7 +30,6 @@ export default function PlayedList() {
       // the hash changes
       if (playlistPlayedStatus !== Status.pending) {
         dispatch(loadPlaylistEntries('played', page, query))
-        setSearchBoxQuery(query || '')
       }
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -30,7 +30,6 @@ export default function PlayerErrorsList() {
       // the hash changes
       if (playerErrorsStatus !== Status.pending) {
         dispatch(loadPlayerErrors(page, query))
-        setSearchBoxQuery(query || '')
       }
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/src/components/playlist/queuing/List.jsx
+++ b/src/components/playlist/queuing/List.jsx
@@ -30,7 +30,6 @@ export default function QueuingList() {
       // or the hash changes
       if (playlistQueuingStatus !== Status.pending) {
         dispatch(loadPlaylistEntries('queuing', page, query))
-        setSearchBoxQuery(query || '')
       }
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/src/components/settings/songTags/List.jsx
+++ b/src/components/settings/songTags/List.jsx
@@ -27,7 +27,6 @@ export default function SongTagsList() {
       // refresh song tags immediately and if the page changes
       if (songTagsStatus !== Status.pending) {
         dispatch(loadSongTags(page, query))
-        setSearchBoxQuery(query || '')
       }
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/src/components/settings/users/List.jsx
+++ b/src/components/settings/users/List.jsx
@@ -28,7 +28,6 @@ export default function UsersList() {
       // refresh the users immediately and if the page changes
       if (listUsersStatus !== Status.pending) {
         dispatch(loadUsers(page, query))
-        setSearchBoxQuery(query || '')
       }
     },
     // eslint-disable-next-line @eslint-react/exhaustive-deps


### PR DESCRIPTION
This PR fixes the problem of search boxes that loose the query when moving to a neighboring tab.

Fixes #280.